### PR TITLE
card 8 - add conditional_language_requirement validator and is_choice_null validator

### DIFF
--- a/ckanext/fluent/plugins.py
+++ b/ckanext/fluent/plugins.py
@@ -36,4 +36,7 @@ class FluentPlugin(p.SingletonPlugin):
                 validators.fluent_tags_output,
             'fluent_core_translated_output':
                 validators.fluent_core_translated_output,
+            'fluent_conditional_language_requirement':
+                validators.fluent_conditional_language_requirement,
+            'fluent_is_choice_null': validators.fluent_is_choice_null
             }


### PR DESCRIPTION
Deze pr voegt 2 validators toe aan de fluent ext. De eerste validator, fluent_conditional_language_requirement, gaat kijken of de beschrijving van een bepaalde taal is ingevuld wanneer die taal is aangeduid als dataset taal. De tweede validator, is_choice_null wordt nog niet gebruikt maar kan later gebruikt worden om optionele fluent velden die leeg zijn als deleted te zetten in de database ==> database consistentie!