### PR TITLE
use new function `benap_lang_text`

### DIFF
--- a/ckanext/fluent/templates/scheming/display_snippets/fluent_large_text_fallback.html
+++ b/ckanext/fluent/templates/scheming/display_snippets/fluent_large_text_fallback.html
@@ -1,6 +1,4 @@
-{% set data = h.render_markdown(h.scheming_language_text(data[field.field_name]) or
-h.benap_scheming_language_text_fallback(data[field.field_name], data['language'])) %}
-
+{% set data = h.render_markdown(h.benap_lang_text(data[field.field_name])) %}
 
 <div id="license-text-container">
   <p id="license-text-preview" style="margin: 0; padding: 0;" data-preview-text="{{ data[:100]|escape }}{% if data|length > 100 %}...{% endif %}"></p>


### PR DESCRIPTION
Note that field['language'] is not passed anymore: in the previous function, this value was just ignored (unused), so to keep the same behavior, this is not passed now, as benap_lang_text *will* use it.

this needs benap-plugin version 4.0.0
see https://github.com/belgium-its-steering-committee/ckanext-benap/commit/05cc99bc228fb0a2338aaaaa54fda467d84710d1 for more information